### PR TITLE
修正前端中的默认后端端口为 5000（当前为5001）

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         // target: 'http://localhost:5002',
-        target: process.env.VITE_API_BASE || 'http://localhost:5001',
+        target: process.env.VITE_API_BASE || 'http://localhost:5000',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, '/api')


### PR DESCRIPTION
## 问题描述

刚才帮朋友部署本项目时发现默认的后端端口被更改成了 5001，导致全部保持默认配置时或运行 start.bat 时，无法找到后端服务导致前端网页出现报错

## 测试环境

+ windows 11

## 测试结果

start.bat 和 手动启动前后端均无问题