### PR TITLE
[fix]: 修复若干小问题

### DIFF
--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
     proxy: {
       '/api': {
         // target: 'http://localhost:5002',
-        target: process.env.VITE_API_BASE || 'http://localhost:5001',
+        target: process.env.VITE_API_BASE || 'http://localhost:5000',
         changeOrigin: true,
         secure: false,
         rewrite: (path) => path.replace(/^\/api/, '/api')

--- a/start.bat
+++ b/start.bat
@@ -202,7 +202,7 @@ if %RETRY_COUNT% gtr %MAX_RETRIES% (
 )
 
 :: 使用PowerShell检查后端健康状态（兼容性更好）
-powershell -Command "try { $response = Invoke-WebRequest -Uri 'http://localhost:5000/api/health' -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop; exit 0 } catch { exit 1 }" >nul 2>&1
+powershell -Command "try { $response = Invoke-WebRequest -Uri 'http://127.0.0.1:5000/api/health' -Proxy $null -UseBasicParsing -TimeoutSec 2 -ErrorAction Stop; exit 0 } catch { exit 1 }" >nul 2>&1
 if errorlevel 1 (
     timeout /t 1 /nobreak >nul
     goto wait_backend


### PR DESCRIPTION
## 问题描述

1. 刚才帮朋友部署本项目时发现默认的后端端口被更改成了 5001，导致全部保持默认配置时或运行 start.bat 时，无法找到后端服务导致前端网页出现报错
2. 在开启系统代理时，start.bat 中的健康检查使用的 localhost 无法被解析，导致超时，虽然可以正常启动前端，但会导致等待 30s 影响用户体验

## 测试环境

+ Windows 11

## 修改内容

+ vite.config.js
+ start.bat

## 测试结果

1. 开启代理后仍然可以快速通过健康检查
2. 前端在运行后不会再报`http proxy`错误